### PR TITLE
Test service and die with HTTP status if JSON decode fails on RPC call.

### DIFF
--- a/lib/Bitcoin/RPC/Client.pm
+++ b/lib/Bitcoin/RPC/Client.pm
@@ -83,7 +83,7 @@ sub AUTOLOAD {
                              SSL_verify_mode => 0 );
    }
 
-   # Build the RPC 
+   # Build the RPC
    my $obj = {
       method => $method,
       params => (ref $_[0] ? $_[0] : [@_]),
@@ -93,11 +93,9 @@ sub AUTOLOAD {
       # Attempt the RPC
       $res = $client->call( $url, $obj );
    } or do {
-      # Test the HTTP service if above RPC fails
+      # Test the HTTP service and die with usable output if above RPC call fails
       my $tr = $client->ua->post($url);
-      if (!$tr->is_success) {
-         die $tr->status_line;
-      }
+      die $tr->status_line;
    };
    if($res) {
       if ($res->is_error) {

--- a/lib/Bitcoin/RPC/Client.pm
+++ b/lib/Bitcoin/RPC/Client.pm
@@ -83,12 +83,22 @@ sub AUTOLOAD {
                              SSL_verify_mode => 0 );
    }
 
+   # Build the RPC 
    my $obj = {
       method => $method,
       params => (ref $_[0] ? $_[0] : [@_]),
    };
-
-   my $res = $client->call( $url, $obj );
+   my $res;
+   eval {
+      # Attempt the RPC
+      $res = $client->call( $url, $obj );
+   } or do {
+      # Test the HTTP service if above RPC fails
+      my $tr = $client->ua->post($url);
+      if (!$tr->is_success) {
+         die $tr->status_line;
+      }
+   };
    if($res) {
       if ($res->is_error) {
           my $content = $res->content;

--- a/t/gh4-json.t
+++ b/t/gh4-json.t
@@ -1,0 +1,26 @@
+#!perl -T
+# Written by Wesley Hinds
+use 5.006;
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+# This is a regression test for github #4. It can work with or without internet since
+# the JSON failure happens either way.
+
+use Bitcoin::RPC::Client;
+
+# We will use 234.198.51.100 as it is designated for test purposes.
+# https://tools.ietf.org/html/rfc6676
+
+eval {
+   my $btc = Bitcoin::RPC::Client->new(
+      user     => "username",
+      password => "p4ssword",
+      host     => "234.198.51.100",
+   );
+   $btc->getblockchaininfo;
+}; 
+
+unlike($@, qr/malformed JSON/, "Handled 'malformed JSON' response correctly.");


### PR DESCRIPTION
This should fix issue #4.